### PR TITLE
Fixing page titles on Lesson & Chapter page routes

### DIFF
--- a/src/pages/chapters/[slug].astro
+++ b/src/pages/chapters/[slug].astro
@@ -30,7 +30,7 @@ const pageFiles = await loadFromCMS({
 });
 ---
 
-<Layout title={`Chapter: ${content.displayname}`}>
+<Layout title={`${content.title}`}>
   <h1>{content.title}</h1>
   <p>Chapter pages coming soon!</p>
   <!-- <pre>{JSON.stringify(content, null, 2)}</pre> -->

--- a/src/pages/lessons/[slug].astro
+++ b/src/pages/lessons/[slug].astro
@@ -42,7 +42,7 @@ const pageFiles = await loadFromCMS({
 });
 ---
 
-<Layout title={`Lesson: ${rawData.title}`}>
+<Layout title={`${rawData.content.title}`}>
   <PageHero title={rawData.content.title}>
     <!-- TODO: map multiple authors to separate PersonBlock components -->
     <Fragment slot="left">


### PR DESCRIPTION
This PR fixes page titles on the Lesson & Chapter page routes and sets them to `Page Title | Earthrise Commons`

This may not be robust enough for all situations; I will open a ticket to investigate if it's possible for either page type to exist without a title (in which case further validation would be necessary)

Closes #13 